### PR TITLE
Fix error handling on Jenkins failure

### DIFF
--- a/status/status.js
+++ b/status/status.js
@@ -1,4 +1,6 @@
 module.exports = function(RED) {
+    "use strict";
+
     /**
      * Get status from a Jenkins instance
      * @param {string} config - The Node-RED node configuration
@@ -15,8 +17,9 @@ module.exports = function(RED) {
             };
             let jenkinsInstance = jenkins(jenkinsConfig);
             jenkinsInstance.info(function(err, data) {
-                if (err) throw err;
+                if (err) return node.error("Error getting info from Jenkins", err);
                 msg.payload = data.jobs[0].color;
+
                 node.send(msg);
             });
         });


### PR DESCRIPTION
Throwing exception from a node crashes the server.
Using node.error instead also has the benefit of enabling
the use of a Catch node

This also fixes the following error at startup:
```
[jenkins-status] SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```